### PR TITLE
fix for proper library path load for MSS 2017

### DIFF
--- a/src/mfx_library_iterator_linux.cpp
+++ b/src/mfx_library_iterator_linux.cpp
@@ -332,8 +332,7 @@ mfxStatus MFXLibraryIterator::Init(eMfxImplType implType, mfxIMPL impl, const mf
     // set the required library's implementation type
     m_implType = implType;
 
-    snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),
-             "%s/%s/%04x/%04x", mfx_storage_opt, mfx_folder, m_vendorID, m_deviceID);
+    snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),"%s/%s", mfx_storage_opt, mfx_folder);
 
     m_libs_num = mfx_list_libraries(m_path, (MFX_LIB_HARDWARE == implType), &m_libs);
 


### PR DESCRIPTION
Needed to fix library/.so loading to support [Intel® Media Server Studio 2017 R1/R2](https://software.intel.com/en-us/blogs/2017/01/04/2017-r2-release-whats-new-in-intel-media-server-studio) 

it should not break prev. versions