### PR TITLE
fix for error value handling

### DIFF
--- a/src/mfx_va_glue.c
+++ b/src/mfx_va_glue.c
@@ -52,7 +52,7 @@ void *mfx_allocate_va(mfxSession session)
     if (!(display = vaGetDisplayDRM(fd)))
         goto fail;
 
-    if (vaInitialize(display, &major, &minor) < 0)
+    if (vaInitialize(display, &major, &minor) != VA_STATUS_SUCCESS)
         goto fail;
 
     ret = MFXVideoCORE_SetHandle(session, MFX_HANDLE_VA_DISPLAY, display);


### PR DESCRIPTION
The only successful VAAPI status is
`#define VA_STATUS_SUCCESS			0x00000000`

The rest are failures:
```
#define VA_STATUS_ERROR_OPERATION_FAILED	0x00000001
#define VA_STATUS_ERROR_ALLOCATION_FAILED	0x00000002
#define VA_STATUS_ERROR_INVALID_DISPLAY		0x00000003
#define VA_STATUS_ERROR_INVALID_CONFIG		0x00000004
#define VA_STATUS_ERROR_INVALID_CONTEXT		0x00000005
#define VA_STATUS_ERROR_INVALID_SURFACE		0x00000006
#define VA_STATUS_ERROR_INVALID_BUFFER		0x00000007
...
```
