### PR TITLE
Don't forcible use -fPIC, check whether it's supported in configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,8 +45,6 @@ libmfx_la_LDFLAGS = -no-undefined -static-libgcc -static-libstdc++
 libmfx_la_LDFLAGS += -version-info $(MFX_LT_CURRENT):$(MFX_LT_REVISION):$(MFX_LT_AGE)
 libmfx_la_LIBADD = $(DLLIB) $(LIBVA_DRM_LIBS) $(LIBVA_X11_LIBS)
 libmfx_la_CPPFLAGS = $(LIBVA_DRM_CFLAGS) $(LIBVA_X11_CFLAGS) $(AM_CPPFLAGS)
-libmfx_la_CXXFLAGS = $(AM_CXXFLAGS) -fPIC
-libmfx_la_CFLAGS = $(AM_CFLAGS) -fPIC
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libmfx.pc

--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,17 @@ AC_SUBST(DLLIB)
 
 AC_PROG_CXX
 
+AC_MSG_CHECKING(whether fPIC compiler option is accepted)
+SAVED_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS="$CXXFLAGS -fPIC -Werror"
+AC_LANG_PUSH(C++)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [return 0;])],
+    [AC_MSG_RESULT(yes)
+     CXXFLAGS="$SAVED_CXXFLAGS -fPIC"],
+    [AC_MSG_RESULT(no)
+     CXXFLAGS="$SAVED_CXXFLAGS"])
+AC_LANG_POP(C++)
+
 LT_INIT([disable-shared])
 
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
While gcc just warns about -fPIC when targeting mingw, clang throws
an error.