### PR TITLE
do not call registry APIs if MEDIASDK_USE_REGISTRY is not set

### DIFF
--- a/src/mfx_win_reg_key.cpp
+++ b/src/mfx_win_reg_key.cpp
@@ -55,7 +55,9 @@ void WinRegKey::Release(void)
     // close the opened key
     if (m_hKey)
     {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
         RegCloseKey(m_hKey);
+#endif
     }
 
     m_hKey = (HKEY) 0;
@@ -64,6 +66,7 @@ void WinRegKey::Release(void)
 
 bool WinRegKey::Open(HKEY hRootKey, const wchar_t *pSubKey, REGSAM samDesired)
 {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     LONG lRes;
     HKEY hTemp;
 
@@ -91,6 +94,9 @@ bool WinRegKey::Open(HKEY hRootKey, const wchar_t *pSubKey, REGSAM samDesired)
     m_hKey = hTemp;
 
     return true;
+#else
+    return false;
+#endif
 
 } // bool WinRegKey::Open(HKEY hRootKey, const wchar_t *pSubKey, REGSAM samDesired)
 
@@ -101,6 +107,7 @@ bool WinRegKey::Open(WinRegKey &rootKey, const wchar_t *pSubKey, REGSAM samDesir
 } // bool WinRegKey::Open(WinRegKey &rootKey, const wchar_t *pSubKey, REGSAM samDesired)
 
 bool WinRegKey::QueryValueSize(const wchar_t *pValueName, DWORD type, LPDWORD pcbData) {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     DWORD keyType = type;
     LONG lRes;
 
@@ -114,10 +121,14 @@ bool WinRegKey::QueryValueSize(const wchar_t *pValueName, DWORD type, LPDWORD pc
     }
 
     return true;
+#else
+    return false;
+#endif
 }
 
 bool WinRegKey::Query(const wchar_t *pValueName, DWORD type, LPBYTE pData, LPDWORD pcbData)
 {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     DWORD keyType = type;
     LONG lRes;
     DWORD dstSize = (pcbData) ? (*pcbData) : (0);
@@ -174,11 +185,15 @@ bool WinRegKey::Query(const wchar_t *pValueName, DWORD type, LPBYTE pData, LPDWO
     }
 
     return true;
+#else
+    return false;
+#endif
 
 } // bool WinRegKey::Query(const wchar_t *pValueName, DWORD type, LPBYTE pData, LPDWORD pcbData)
 
 bool WinRegKey::EnumValue(DWORD index, wchar_t *pValueName, LPDWORD pcchValueName, LPDWORD pType)
 {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     LONG lRes;
 
     // enum the values
@@ -190,11 +205,15 @@ bool WinRegKey::EnumValue(DWORD index, wchar_t *pValueName, LPDWORD pcchValueNam
     }
 
     return true;
+#else
+    return false;
+#endif
 
 } // bool WinRegKey::EnumValue(DWORD index, wchar_t *pValueName, LPDWORD pcchValueName, LPDWORD pType)
 
 bool WinRegKey::EnumKey(DWORD index, wchar_t *pValueName, LPDWORD pcchValueName)
 {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     LONG lRes;
 
     // enum the keys
@@ -207,11 +226,15 @@ bool WinRegKey::EnumKey(DWORD index, wchar_t *pValueName, LPDWORD pcchValueName)
     }
 
     return true;
+#else
+    return false;
+#endif
 
 } // bool WinRegKey::EnumKey(DWORD index, wchar_t *pValueName, LPDWORD pcchValueName)
 
 bool WinRegKey::QueryInfo(LPDWORD lpcSubkeys)
 {
+#if defined(MEDIASDK_USE_REGISTRY) || (!defined(MEDIASDK_UWP_LOADER) && !defined(MEDIASDK_UWP_PROCTABLE))
     LONG lRes;
 
     lRes = RegQueryInfoKeyW(m_hKey, NULL, 0, 0, lpcSubkeys, 0, 0, 0, 0, 0, 0, 0);
@@ -220,6 +243,9 @@ bool WinRegKey::QueryInfo(LPDWORD lpcSubkeys)
         return false;
     }
     return true;
+#else
+    return false;
+#endif
 
 } //bool QueryInfo(LPDWORD lpcSubkeys);
 


### PR DESCRIPTION
Or building for UWP where it's not allowed.

The preprocessor test matches other tests in the code.