### PR TITLE
CMake: Install headers into include/mfx and check minimum version first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,7 @@ add_definitions(
 configure_file (${CMAKE_SOURCE_DIR}/libmfx.pc.cmake ${CMAKE_BINARY_DIR}/libmfx.pc @ONLY)
 
 add_library( mfx STATIC ${SOURCES} )
-file(GLOB MFX_HEADERS "${CMAKE_SOURCE_DIR}/mfx/*.h")
-install (FILES ${MFX_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+install (DIRECTORY ${CMAKE_SOURCE_DIR}/mfx DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")
 install (FILES ${CMAKE_BINARY_DIR}/libmfx.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 install (TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 cmake_minimum_required(VERSION 2.6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 2.6)
+
 project( libmfx )
 
 # FIXME Adds support for using system/other install of intel media sdk
@@ -57,4 +59,3 @@ add_library( mfx STATIC ${SOURCES} )
 install (DIRECTORY ${CMAKE_SOURCE_DIR}/mfx DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")
 install (FILES ${CMAKE_BINARY_DIR}/libmfx.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 install (TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-cmake_minimum_required(VERSION 2.6)


### PR DESCRIPTION
While working on a project with Thomas Volkert (Net-Zeal) we ran into the weird situation that  on my machine the mfx headers were top-level in the include directory after installation while on his machine they were in include/mfx.

It turns out that he used autotools to install mfx_dispatch while I used CMake, and they currently behave differently. This patch fixes that and now also puts the headers into include/mfx when using CMake to build and install mfx_dispatch.

Additionally, I've moved the `cmake_minimum_required` call to the top of the CMakeLists.txt file, as the minimum required version changes the behavior of subsequent `project` calls (see also https://cmake.org/cmake/help/v3.15/command/cmake_minimum_required.html).