### PR TITLE
Add missing headers

### DIFF
--- a/mfx/mfxadapter.h
+++ b/mfx/mfxadapter.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "mfxdefs.h"
+#if (MFX_VERSION >= 1031)
+#ifndef __MFXADAPTER_H__
+#define __MFXADAPTER_H__
+
+#include "mfxstructures.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+mfxStatus MFXQueryAdapters(mfxComponentInfo* input_info, mfxAdaptersInfo* adapters);
+mfxStatus MFXQueryAdaptersDecode(mfxBitstream* bitstream, mfxU32 codec_id, mfxAdaptersInfo* adapters);
+mfxStatus MFXQueryAdaptersNumber(mfxU32* num_adapters);
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // __MFXADAPTER_H__
+#endif

--- a/mfx/mfxaudio++.h
+++ b/mfx/mfxaudio++.h
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#ifndef __MFXAUDIOPLUSPLUS_H
+#define __MFXAUDIOPLUSPLUS_H
+
+#include "mfxaudio.h"
+
+class MFXAudioSession
+{
+public:
+    MFXAudioSession(void) { m_session = (mfxSession) 0; }
+    virtual ~MFXAudioSession(void) { Close(); }
+
+    virtual mfxStatus Init(mfxIMPL impl, mfxVersion *ver) { return MFXInit(impl, ver, &m_session); }
+    virtual mfxStatus Close(void)
+    {
+        mfxStatus mfxRes;
+        mfxRes = MFXClose(m_session); m_session = (mfxSession) 0;
+        return mfxRes;
+    }
+
+    virtual mfxStatus QueryIMPL(mfxIMPL *impl) { return MFXQueryIMPL(m_session, impl); }
+    virtual mfxStatus QueryVersion(mfxVersion *version) { return MFXQueryVersion(m_session, version); }
+
+    virtual mfxStatus JoinSession(mfxSession child_session) { return MFXJoinSession(m_session, child_session);}
+    virtual mfxStatus DisjoinSession( ) { return MFXDisjoinSession(m_session);}
+    virtual mfxStatus CloneSession( mfxSession *clone) { return MFXCloneSession(m_session, clone);}
+    virtual mfxStatus SetPriority( mfxPriority priority) { return MFXSetPriority(m_session, priority);}
+    virtual mfxStatus GetPriority( mfxPriority *priority) { return MFXGetPriority(m_session, priority);}
+
+    virtual mfxStatus SyncOperation(mfxSyncPoint syncp, mfxU32 wait) { return MFXAudioCORE_SyncOperation(m_session, syncp, wait); }
+
+    virtual operator mfxSession (void) { return m_session; }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+
+class MFXAudioDECODE
+{
+public:
+
+    MFXAudioDECODE(mfxSession session) { m_session = session; }
+    virtual ~MFXAudioDECODE(void) { Close(); }
+
+    virtual mfxStatus Query(mfxAudioParam *in, mfxAudioParam *out) { return MFXAudioDECODE_Query(m_session, in, out); }
+    virtual mfxStatus DecodeHeader(mfxBitstream *bs, mfxAudioParam *par) { return MFXAudioDECODE_DecodeHeader(m_session, bs, par); }
+    virtual mfxStatus QueryIOSize(mfxAudioParam *par, mfxAudioAllocRequest *request) { return MFXAudioDECODE_QueryIOSize(m_session, par, request); }
+    virtual mfxStatus Init(mfxAudioParam *par) { return MFXAudioDECODE_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxAudioParam *par) { return MFXAudioDECODE_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXAudioDECODE_Close(m_session); }
+    virtual mfxStatus GetAudioParam(mfxAudioParam *par) { return MFXAudioDECODE_GetAudioParam(m_session, par); }
+    virtual mfxStatus DecodeFrameAsync(mfxBitstream *bs, mfxAudioFrame *frame, mfxSyncPoint *syncp) { return MFXAudioDECODE_DecodeFrameAsync(m_session, bs, frame, syncp); }
+
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+
+class MFXAudioENCODE
+{
+public:
+
+    MFXAudioENCODE(mfxSession session) { m_session = session; }
+    virtual ~MFXAudioENCODE(void) { Close(); }
+
+    virtual mfxStatus Query(mfxAudioParam *in, mfxAudioParam *out) { return MFXAudioENCODE_Query(m_session, in, out); }
+    virtual mfxStatus QueryIOSize(mfxAudioParam *par, mfxAudioAllocRequest *request) { return MFXAudioENCODE_QueryIOSize(m_session, par, request); }
+    virtual mfxStatus Init(mfxAudioParam *par) { return MFXAudioENCODE_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxAudioParam *par) { return MFXAudioENCODE_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXAudioENCODE_Close(m_session); }
+    virtual mfxStatus GetAudioParam(mfxAudioParam *par) { return MFXAudioENCODE_GetAudioParam(m_session, par); }
+    virtual mfxStatus EncodeFrameAsync(mfxAudioFrame *frame, mfxBitstream *buffer_out, mfxSyncPoint *syncp) { return MFXAudioENCODE_EncodeFrameAsync(m_session, frame, buffer_out, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+#endif

--- a/mfx/mfxdispatcherprefixedfunctions.h
+++ b/mfx/mfxdispatcherprefixedfunctions.h
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#ifndef __MFXDISPATCHERPREFIXEDFUNCTIONS_H__
+#define __MFXDISPATCHERPREFIXEDFUNCTIONS_H__
+
+// API 1.0 functions
+#define MFXInit                          disp_MFXInit
+#define MFXClose                         disp_MFXClose
+#define MFXQueryIMPL                     disp_MFXQueryIMPL
+#define MFXQueryVersion                  disp_MFXQueryVersion
+
+#define MFXJoinSession                   disp_MFXJoinSession
+#define MFXDisjoinSession                disp_MFXDisjoinSession
+#define MFXCloneSession                  disp_MFXCloneSession
+#define MFXSetPriority                   disp_MFXSetPriority
+#define MFXGetPriority                   disp_MFXGetPriority
+
+#define MFXVideoCORE_SetBufferAllocator  disp_MFXVideoCORE_SetBufferAllocator
+#define MFXVideoCORE_SetFrameAllocator   disp_MFXVideoCORE_SetFrameAllocator
+#define MFXVideoCORE_SetHandle           disp_MFXVideoCORE_SetHandle
+#define MFXVideoCORE_GetHandle           disp_MFXVideoCORE_GetHandle
+#define MFXVideoCORE_SyncOperation       disp_MFXVideoCORE_SyncOperation
+
+#define MFXVideoENCODE_Query             disp_MFXVideoENCODE_Query
+#define MFXVideoENCODE_QueryIOSurf       disp_MFXVideoENCODE_QueryIOSurf
+#define MFXVideoENCODE_Init              disp_MFXVideoENCODE_Init
+#define MFXVideoENCODE_Reset             disp_MFXVideoENCODE_Reset
+#define MFXVideoENCODE_Close             disp_MFXVideoENCODE_Close
+#define MFXVideoENCODE_GetVideoParam     disp_MFXVideoENCODE_GetVideoParam
+#define MFXVideoENCODE_GetEncodeStat     disp_MFXVideoENCODE_GetEncodeStat
+#define MFXVideoENCODE_EncodeFrameAsync  disp_MFXVideoENCODE_EncodeFrameAsync
+
+#define MFXVideoDECODE_Query             disp_MFXVideoDECODE_Query
+#define MFXVideoDECODE_DecodeHeader      disp_MFXVideoDECODE_DecodeHeader
+#define MFXVideoDECODE_QueryIOSurf       disp_MFXVideoDECODE_QueryIOSurf
+#define MFXVideoDECODE_Init              disp_MFXVideoDECODE_Init
+#define MFXVideoDECODE_Reset             disp_MFXVideoDECODE_Reset
+#define MFXVideoDECODE_Close             disp_MFXVideoDECODE_Close
+#define MFXVideoDECODE_GetVideoParam     disp_MFXVideoDECODE_GetVideoParam
+#define MFXVideoDECODE_GetDecodeStat     disp_MFXVideoDECODE_GetDecodeStat
+#define MFXVideoDECODE_SetSkipMode       disp_MFXVideoDECODE_SetSkipMode
+#define MFXVideoDECODE_GetPayload        disp_MFXVideoDECODE_GetPayload
+#define MFXVideoDECODE_DecodeFrameAsync  disp_MFXVideoDECODE_DecodeFrameAsync
+
+#define MFXVideoVPP_Query                disp_MFXVideoVPP_Query
+#define MFXVideoVPP_QueryIOSurf          disp_MFXVideoVPP_QueryIOSurf
+#define MFXVideoVPP_Init                 disp_MFXVideoVPP_Init
+#define MFXVideoVPP_Reset                disp_MFXVideoVPP_Reset
+#define MFXVideoVPP_Close                disp_MFXVideoVPP_Close
+
+#define MFXVideoVPP_GetVideoParam        disp_MFXVideoVPP_GetVideoParam
+#define MFXVideoVPP_GetVPPStat           disp_MFXVideoVPP_GetVPPStat
+#define MFXVideoVPP_RunFrameVPPAsync     disp_MFXVideoVPP_RunFrameVPPAsync
+
+// API 1.1 functions
+#define MFXVideoUSER_Register            disp_MFXVideoUSER_Register
+#define MFXVideoUSER_Unregister          disp_MFXVideoUSER_Unregister
+#define MFXVideoUSER_ProcessFrameAsync   disp_MFXVideoUSER_ProcessFrameAsync
+
+// API 1.10 functions
+
+#define MFXVideoENC_Query                disp_MFXVideoENC_Query
+#define MFXVideoENC_QueryIOSurf          disp_MFXVideoENC_QueryIOSurf
+#define MFXVideoENC_Init                 disp_MFXVideoENC_Init
+#define MFXVideoENC_Reset                disp_MFXVideoENC_Reset
+#define MFXVideoENC_Close                disp_MFXVideoENC_Close
+#define MFXVideoENC_ProcessFrameAsync    disp_MFXVideoENC_ProcessFrameAsync
+#define MFXVideoVPP_RunFrameVPPAsyncEx   disp_MFXVideoVPP_RunFrameVPPAsyncEx
+#define MFXVideoUSER_Load                disp_MFXVideoUSER_Load
+#define MFXVideoUSER_UnLoad              disp_MFXVideoUSER_UnLoad
+
+// API 1.11 functions
+
+#define MFXVideoPAK_Query                disp_MFXVideoPAK_Query
+#define MFXVideoPAK_QueryIOSurf          disp_MFXVideoPAK_QueryIOSurf
+#define MFXVideoPAK_Init                 disp_MFXVideoPAK_Init
+#define MFXVideoPAK_Reset                disp_MFXVideoPAK_Reset
+#define MFXVideoPAK_Close                disp_MFXVideoPAK_Close
+#define MFXVideoPAK_ProcessFrameAsync    disp_MFXVideoPAK_ProcessFrameAsync
+
+// API 1.13 functions
+
+#define MFXVideoUSER_LoadByPath          disp_MFXVideoUSER_LoadByPath
+
+// API 1.14 functions
+#define MFXInitEx                        disp_MFXInitEx
+#define MFXDoWork                        disp_MFXDoWork
+
+// Audio library functions
+
+// API 1.8 functions
+
+#define MFXAudioCORE_SyncOperation       disp_MFXAudioCORE_SyncOperation
+#define MFXAudioENCODE_Query             disp_MFXAudioENCODE_Query
+#define MFXAudioENCODE_QueryIOSize       disp_MFXAudioENCODE_QueryIOSize
+#define MFXAudioENCODE_Init              disp_MFXAudioENCODE_Init
+#define MFXAudioENCODE_Reset             disp_MFXAudioENCODE_Reset
+#define MFXAudioENCODE_Close             disp_MFXAudioENCODE_Close
+#define MFXAudioENCODE_GetAudioParam     disp_MFXAudioENCODE_GetAudioParam
+#define MFXAudioENCODE_EncodeFrameAsync  disp_MFXAudioENCODE_EncodeFrameAsync
+
+#define MFXAudioDECODE_Query             disp_MFXAudioDECODE_Query
+#define MFXAudioDECODE_DecodeHeader      disp_MFXAudioDECODE_DecodeHeader
+#define MFXAudioDECODE_Init              disp_MFXAudioDECODE_Init
+#define MFXAudioDECODE_Reset             disp_MFXAudioDECODE_Reset
+#define MFXAudioDECODE_Close             disp_MFXAudioDECODE_Close
+#define MFXAudioDECODE_QueryIOSize       disp_MFXAudioDECODE_QueryIOSize
+#define MFXAudioDECODE_GetAudioParam     disp_MFXAudioDECODE_GetAudioParam
+#define MFXAudioDECODE_DecodeFrameAsync  disp_MFXAudioDECODE_DecodeFrameAsync
+
+// API 1.9 functions
+
+#define MFXAudioUSER_Register            disp_MFXAudioUSER_Register
+#define MFXAudioUSER_Unregister          disp_MFXAudioUSER_Unregister
+#define MFXAudioUSER_ProcessFrameAsync   disp_MFXAudioUSER_ProcessFrameAsync
+#define MFXAudioUSER_Load                disp_MFXAudioUSER_Load
+#define MFXAudioUSER_UnLoad              disp_MFXAudioUSER_UnLoad
+
+// API 1.19 functions
+
+#define MFXVideoENC_GetVideoParam        disp_MFXVideoENC_GetVideoParam
+#define MFXVideoPAK_GetVideoParam        disp_MFXVideoPAK_GetVideoParam
+#define MFXVideoCORE_QueryPlatform       disp_MFXVideoCORE_QueryPlatform
+#define MFXVideoUSER_GetPlugin           disp_MFXVideoUSER_GetPlugin
+
+#endif 

--- a/mfx/mfxpcp.h
+++ b/mfx/mfxpcp.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#ifndef __MFXPCP_H__
+#define __MFXPCP_H__
+#include "mfxstructures.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif /* __cplusplus */
+
+#if MFX_VERSION >= 1030
+/* Protected in mfxVideoParam */
+enum {
+    MFX_PROTECTION_CENC_WV_CLASSIC      = 0x0004,
+    MFX_PROTECTION_CENC_WV_GOOGLE_DASH  = 0x0005,
+};
+
+/* Extended Buffer Ids */
+enum {
+    MFX_EXTBUFF_CENC_PARAM          = MFX_MAKEFOURCC('C','E','N','P')
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct _mfxExtCencParam{
+    mfxExtBuffer Header;
+
+    mfxU32 StatusReportIndex;
+    mfxU32 reserved[15];
+} mfxExtCencParam;
+MFX_PACK_END()
+#endif
+
+#ifdef __cplusplus
+} // extern "C"
+#endif /* __cplusplus */
+
+#endif
+

--- a/mfx/mfxplugin++.h
+++ b/mfx/mfxplugin++.h
@@ -1,0 +1,721 @@
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef __MFXPLUGINPLUSPLUS_H
+#define __MFXPLUGINPLUSPLUS_H
+
+#include "mfxplugin.h"
+
+// base class for MFXVideoUSER/MFXAudioUSER API
+
+class MFXBaseUSER {
+public:
+    explicit MFXBaseUSER(mfxSession session = NULL)
+        : m_session(session){}
+
+    virtual ~MFXBaseUSER() {};
+
+    virtual mfxStatus Register(mfxU32 type, const mfxPlugin *par) = 0;
+    virtual mfxStatus Unregister(mfxU32 type) = 0;
+    virtual mfxStatus ProcessFrameAsync(const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp) = 0;
+
+protected:
+    mfxSession m_session;
+};
+
+//c++ wrapper over only 3 exposed functions from MFXVideoUSER module
+class MFXVideoUSER: public MFXBaseUSER {
+public:
+    explicit MFXVideoUSER(mfxSession session = NULL)
+        : MFXBaseUSER(session){}
+
+    virtual mfxStatus Register(mfxU32 type, const mfxPlugin *par) {
+        return MFXVideoUSER_Register(m_session, type, par);
+    }
+    virtual mfxStatus Unregister(mfxU32 type) {
+        return MFXVideoUSER_Unregister(m_session, type);
+    }
+    virtual mfxStatus ProcessFrameAsync(const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp) {
+        return MFXVideoUSER_ProcessFrameAsync(m_session, in, in_num, out, out_num, syncp);
+    }
+};
+
+//c++ wrapper over only 3 exposed functions from MFXAudioUSER module
+class MFXAudioUSER: public MFXBaseUSER {
+public:
+    explicit MFXAudioUSER(mfxSession session = NULL)
+        : MFXBaseUSER(session){}
+
+    virtual mfxStatus Register(mfxU32 type, const mfxPlugin *par) {
+        return MFXAudioUSER_Register(m_session, type, par);
+    }
+    virtual mfxStatus Unregister(mfxU32 type) {
+        return MFXAudioUSER_Unregister(m_session, type);
+    }
+    virtual mfxStatus ProcessFrameAsync(const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxSyncPoint *syncp) {
+        return MFXAudioUSER_ProcessFrameAsync(m_session, in, in_num, out, out_num, syncp);
+    }
+};
+
+
+//initialize mfxPlugin struct
+class MFXPluginParam {
+    mfxPluginParam m_param;
+
+public:
+    MFXPluginParam(mfxU32 CodecId, mfxU32  Type, mfxPluginUID uid, mfxThreadPolicy ThreadPolicy = MFX_THREADPOLICY_SERIAL, mfxU32  MaxThreadNum = 1)
+        : m_param() {
+        m_param.PluginUID = uid;
+        m_param.Type = Type;
+        m_param.CodecId = CodecId;
+        m_param.MaxThreadNum = MaxThreadNum;
+        m_param.ThreadPolicy = ThreadPolicy;
+    }
+    operator const mfxPluginParam& () const {
+        return m_param;
+    }
+    operator mfxPluginParam& () {
+        return m_param;
+    }
+};
+
+//common interface part for every plugin: decoder/encoder and generic
+struct MFXPlugin
+{
+    virtual ~MFXPlugin() {};
+    //init function always required for any transform or codec plugins, for codec plugins it maps to callback from MediaSDK
+    //for generic plugin application should call it
+    //MediaSDK mfxPlugin API mapping
+    virtual mfxStatus PluginInit(mfxCoreInterface *core) = 0;
+    //release CoreInterface, and destroy plugin state, not destroy plugin instance
+    virtual mfxStatus PluginClose() = 0;
+    virtual mfxStatus GetPluginParam(mfxPluginParam *par) = 0;
+    virtual mfxStatus Execute(mfxThreadTask task, mfxU32 uid_p, mfxU32 uid_a) = 0;
+    virtual mfxStatus FreeResources(mfxThreadTask task, mfxStatus sts) = 0;
+    //destroy plugin due to shared module distribution model plugin wont support virtual destructor
+    virtual void      Release() = 0;
+    //release resources associated with current instance of plugin, but do not release CoreInterface related resource set in pluginInit
+    virtual mfxStatus Close()  = 0;
+    //communication protocol between particular version of plugin and application
+    virtual mfxStatus SetAuxParams(void* auxParam, int auxParamSize) = 0;
+};
+
+//common extension interface that codec plugins should expose additionally to MFXPlugin
+struct MFXCodecPlugin : MFXPlugin
+{
+    virtual mfxStatus Init(mfxVideoParam *par) = 0;
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *in, mfxFrameAllocRequest *out) = 0;
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) =0;
+    virtual mfxStatus Reset(mfxVideoParam *par) = 0;
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) = 0;
+};
+
+//common extension interface that audio codec plugins should expose additionally to MFXPlugin
+struct MFXAudioCodecPlugin : MFXPlugin
+{
+    virtual mfxStatus Init(mfxAudioParam *par) = 0;
+    virtual mfxStatus Query(mfxAudioParam *in, mfxAudioParam *out) =0;
+    virtual mfxStatus QueryIOSize(mfxAudioParam *par, mfxAudioAllocRequest *request) = 0;
+    virtual mfxStatus Reset(mfxAudioParam *par) = 0;
+    virtual mfxStatus GetAudioParam(mfxAudioParam *par) = 0;
+};
+
+//general purpose transform plugin interface, not a codec plugin
+struct MFXGenericPlugin : MFXPlugin
+{
+    virtual mfxStatus Init(mfxVideoParam *par) = 0;
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *in, mfxFrameAllocRequest *out) = 0;
+    virtual mfxStatus Submit(const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxThreadTask *task) = 0;
+};
+
+//decoder plugins may only support this interface
+struct MFXDecoderPlugin : MFXCodecPlugin
+{
+    virtual mfxStatus DecodeHeader(mfxBitstream *bs, mfxVideoParam *par) = 0;
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) = 0;
+    virtual mfxStatus DecodeFrameSubmit(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out,  mfxThreadTask *task) = 0;
+};
+
+//audio decoder plugins may only support this interface
+struct MFXAudioDecoderPlugin : MFXAudioCodecPlugin
+{
+    virtual mfxStatus DecodeHeader(mfxBitstream *bs, mfxAudioParam *par) = 0;
+//    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) = 0;
+    virtual mfxStatus DecodeFrameSubmit(mfxBitstream *in, mfxAudioFrame *out, mfxThreadTask *task) = 0;
+};
+
+//encoder plugins may only support this interface
+struct MFXEncoderPlugin : MFXCodecPlugin
+{
+    virtual mfxStatus EncodeFrameSubmit(mfxEncodeCtrl *ctrl, mfxFrameSurface1 *surface, mfxBitstream *bs, mfxThreadTask *task) = 0;
+};
+
+//audio encoder plugins may only support this interface
+struct MFXAudioEncoderPlugin : MFXAudioCodecPlugin
+{
+    virtual mfxStatus EncodeFrameSubmit(mfxAudioFrame *aFrame, mfxBitstream *out, mfxThreadTask *task) = 0;
+};
+
+//vpp plugins may only support this interface
+struct MFXVPPPlugin : MFXCodecPlugin
+{
+    virtual mfxStatus VPPFrameSubmit(mfxFrameSurface1 *surface_in, mfxFrameSurface1 *surface_out, mfxExtVppAuxData *aux, mfxThreadTask *task) = 0;
+    virtual mfxStatus VPPFrameSubmitEx(mfxFrameSurface1 *in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxThreadTask *task) = 0;
+};
+
+struct MFXEncPlugin : MFXCodecPlugin
+{
+    virtual mfxStatus EncFrameSubmit(mfxENCInput *in, mfxENCOutput *out, mfxThreadTask *task) = 0;
+};
+
+
+
+
+class MFXCoreInterface
+{
+protected:
+    mfxCoreInterface m_core;
+public:
+
+    MFXCoreInterface()
+        : m_core() {
+    }
+    MFXCoreInterface(const mfxCoreInterface & pCore)
+        : m_core(pCore) {
+    }
+
+    MFXCoreInterface(const MFXCoreInterface & that)
+        : m_core(that.m_core) {
+    }
+    MFXCoreInterface &operator = (const MFXCoreInterface & that)
+    {
+        m_core = that.m_core;
+        return *this;
+    }
+    bool IsCoreSet() {
+        return m_core.pthis != 0;
+    }
+    mfxStatus GetCoreParam(mfxCoreParam *par) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.GetCoreParam(m_core.pthis, par);
+    }
+    mfxStatus GetHandle (mfxHandleType type, mfxHDL *handle) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.GetHandle(m_core.pthis, type, handle);
+    }
+    mfxStatus IncreaseReference (mfxFrameData *fd) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.IncreaseReference(m_core.pthis, fd);
+    }
+    mfxStatus DecreaseReference (mfxFrameData *fd) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.DecreaseReference(m_core.pthis, fd);
+    }
+    mfxStatus CopyFrame (mfxFrameSurface1 *dst, mfxFrameSurface1 *src) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.CopyFrame(m_core.pthis, dst, src);
+    }
+    mfxStatus CopyBuffer(mfxU8 *dst, mfxU32 size, mfxFrameSurface1 *src) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.CopyBuffer(m_core.pthis, dst, size, src);
+    }
+    mfxStatus MapOpaqueSurface(mfxU32  num, mfxU32  type, mfxFrameSurface1 **op_surf) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.MapOpaqueSurface(m_core.pthis, num, type, op_surf);
+    }
+    mfxStatus UnmapOpaqueSurface(mfxU32  num, mfxU32  type, mfxFrameSurface1 **op_surf) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.UnmapOpaqueSurface(m_core.pthis, num, type, op_surf);
+    }
+    mfxStatus GetRealSurface(mfxFrameSurface1 *op_surf, mfxFrameSurface1 **surf) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.GetRealSurface(m_core.pthis, op_surf, surf);
+    }
+    mfxStatus GetOpaqueSurface(mfxFrameSurface1 *surf, mfxFrameSurface1 **op_surf) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.GetOpaqueSurface(m_core.pthis, surf, op_surf);
+    }
+    mfxStatus CreateAccelerationDevice(mfxHandleType type, mfxHDL *handle) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.CreateAccelerationDevice(m_core.pthis, type, handle);
+    }
+    mfxFrameAllocator & FrameAllocator() {
+        return m_core.FrameAllocator;
+    }
+    mfxStatus GetFrameHandle(mfxFrameData *fd, mfxHDL *handle) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.GetFrameHandle(m_core.pthis, fd, handle);
+    }
+    mfxStatus QueryPlatform(mfxPlatform *platform) {
+        if (!IsCoreSet()) {
+            return MFX_ERR_NULL_PTR;
+        }
+        return m_core.QueryPlatform(m_core.pthis, platform);
+    }
+} ;
+
+/* Class adapter between "C" structure mfxPlugin and C++ interface MFXPlugin */
+
+namespace detail
+{
+    template <class T>
+    class MFXPluginAdapterBase
+    {
+    protected:
+        mfxPlugin m_mfxAPI;
+    public:
+        MFXPluginAdapterBase( T *plugin, mfxVideoCodecPlugin *pCodec = NULL)
+            : m_mfxAPI()
+        {
+            SetupCallbacks(plugin, pCodec);
+        }
+
+        MFXPluginAdapterBase( T *plugin, mfxAudioCodecPlugin *pCodec)
+            : m_mfxAPI()
+        {
+            SetupCallbacks(plugin, pCodec);
+        }
+
+        operator  mfxPlugin () const {
+            return m_mfxAPI;
+        }
+        void SetupCallbacks(T *plugin) {
+            m_mfxAPI.pthis = plugin;
+            m_mfxAPI.PluginInit = _PluginInit;
+            m_mfxAPI.PluginClose = _PluginClose;
+            m_mfxAPI.GetPluginParam = _GetPluginParam;
+            m_mfxAPI.Submit = 0;
+            m_mfxAPI.Execute = _Execute;
+            m_mfxAPI.FreeResources = _FreeResources;
+        }
+
+        void SetupCallbacks( T *plugin, mfxVideoCodecPlugin *pCodec) {
+            SetupCallbacks(plugin);
+            m_mfxAPI.Video = pCodec;
+        }
+
+        void SetupCallbacks( T *plugin, mfxAudioCodecPlugin *pCodec) {
+            SetupCallbacks(plugin);
+            m_mfxAPI.Audio = pCodec;
+        }
+    private:
+
+        static mfxStatus _PluginInit(mfxHDL pthis, mfxCoreInterface *core) {
+            return reinterpret_cast<T*>(pthis)->PluginInit(core);
+        }
+        static mfxStatus _PluginClose(mfxHDL pthis) {
+            return reinterpret_cast<T*>(pthis)->PluginClose();
+        }
+        static mfxStatus _GetPluginParam(mfxHDL pthis, mfxPluginParam *par) {
+            return reinterpret_cast<T*>(pthis)->GetPluginParam(par);
+        }
+        static mfxStatus _Execute(mfxHDL pthis, mfxThreadTask task, mfxU32 thread_id, mfxU32 call_count) {
+            return reinterpret_cast<T*>(pthis)->Execute(task, thread_id, call_count);
+        }
+        static mfxStatus _FreeResources(mfxHDL pthis, mfxThreadTask task, mfxStatus sts) {
+            return reinterpret_cast<T*>(pthis)->FreeResources(task, sts);
+        }
+    };
+
+    template<class T>
+    class MFXCodecPluginAdapterBase : public MFXPluginAdapterBase<T>
+    {
+    protected:
+        //stub to feed mediasdk plugin API
+        mfxVideoCodecPlugin   m_codecPlg;
+    public:
+        MFXCodecPluginAdapterBase(T * pCodecPlg)
+            : MFXPluginAdapterBase<T>(pCodecPlg, &m_codecPlg)
+            , m_codecPlg()
+        {
+            m_codecPlg.Query = _Query;
+            m_codecPlg.QueryIOSurf = _QueryIOSurf ;
+            m_codecPlg.Init = _Init;
+            m_codecPlg.Reset = _Reset;
+            m_codecPlg.Close = _Close;
+            m_codecPlg.GetVideoParam = _GetVideoParam;
+        }
+        MFXCodecPluginAdapterBase(const MFXCodecPluginAdapterBase<T> & that)
+            : MFXPluginAdapterBase<T>(reinterpret_cast<T*>(that.m_mfxAPI.pthis), &m_codecPlg)
+            , m_codecPlg() {
+            SetupCallbacks();
+        }
+        MFXCodecPluginAdapterBase<T>& operator = (const MFXCodecPluginAdapterBase<T> & that) {
+            MFXPluginAdapterBase<T> :: SetupCallbacks(reinterpret_cast<T*>(that.m_mfxAPI.pthis), &m_codecPlg);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.Query = _Query;
+            m_codecPlg.QueryIOSurf = _QueryIOSurf ;
+            m_codecPlg.Init = _Init;
+            m_codecPlg.Reset = _Reset;
+            m_codecPlg.Close = _Close;
+            m_codecPlg.GetVideoParam = _GetVideoParam;
+        }
+        static mfxStatus _Query(mfxHDL pthis, mfxVideoParam *in, mfxVideoParam *out) {
+            return reinterpret_cast<T*>(pthis)->Query(in, out);
+        }
+        static mfxStatus _QueryIOSurf(mfxHDL pthis, mfxVideoParam *par, mfxFrameAllocRequest *in,  mfxFrameAllocRequest *out){
+            return reinterpret_cast<T*>(pthis)->QueryIOSurf(par, in, out);
+        }
+        static mfxStatus _Init(mfxHDL pthis, mfxVideoParam *par){
+            return reinterpret_cast<T*>(pthis)->Init(par);
+        }
+        static mfxStatus _Reset(mfxHDL pthis, mfxVideoParam *par){
+            return reinterpret_cast<T*>(pthis)->Reset(par);
+        }
+        static mfxStatus _Close(mfxHDL pthis) {
+            return reinterpret_cast<T*>(pthis)->Close();
+        }
+        static mfxStatus _GetVideoParam(mfxHDL pthis, mfxVideoParam *par) {
+            return reinterpret_cast<T*>(pthis)->GetVideoParam(par);
+        }
+    };
+
+    template<class T>
+    class MFXAudioCodecPluginAdapterBase : public MFXPluginAdapterBase<T>
+    {
+    protected:
+        //stub to feed mediasdk plugin API
+        mfxAudioCodecPlugin   m_codecPlg;
+    public:
+        MFXAudioCodecPluginAdapterBase(T * pCodecPlg)
+            : MFXPluginAdapterBase<T>(pCodecPlg, &m_codecPlg)
+            , m_codecPlg()
+        {
+            m_codecPlg.Query = _Query;
+            m_codecPlg.QueryIOSize = _QueryIOSize ;
+            m_codecPlg.Init = _Init;
+            m_codecPlg.Reset = _Reset;
+            m_codecPlg.Close = _Close;
+            m_codecPlg.GetAudioParam = _GetAudioParam;
+        }
+        MFXAudioCodecPluginAdapterBase(const MFXCodecPluginAdapterBase<T> & that)
+            : MFXPluginAdapterBase<T>(reinterpret_cast<T*>(that.m_mfxAPI.pthis), &m_codecPlg)
+            , m_codecPlg() {
+            SetupCallbacks();
+        }
+        MFXAudioCodecPluginAdapterBase<T>& operator = (const MFXAudioCodecPluginAdapterBase<T> & that) {
+            MFXPluginAdapterBase<T> :: SetupCallbacks(reinterpret_cast<T*>(that.m_mfxAPI.pthis), &m_codecPlg);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.Query = _Query;
+            m_codecPlg.QueryIOSize = _QueryIOSize;
+            m_codecPlg.Init = _Init;
+            m_codecPlg.Reset = _Reset;
+            m_codecPlg.Close = _Close;
+            m_codecPlg.GetAudioParam = _GetAudioParam;
+        }
+        static mfxStatus _Query(mfxHDL pthis, mfxAudioParam *in, mfxAudioParam *out) {
+            return reinterpret_cast<T*>(pthis)->Query(in, out);
+        }
+        static mfxStatus _QueryIOSize(mfxHDL pthis, mfxAudioParam *par, mfxAudioAllocRequest *request){
+            return reinterpret_cast<T*>(pthis)->QueryIOSize(par, request);
+        }
+        static mfxStatus _Init(mfxHDL pthis, mfxAudioParam *par){
+            return reinterpret_cast<T*>(pthis)->Init(par);
+        }
+        static mfxStatus _Reset(mfxHDL pthis, mfxAudioParam *par){
+            return reinterpret_cast<T*>(pthis)->Reset(par);
+        }
+        static mfxStatus _Close(mfxHDL pthis) {
+            return reinterpret_cast<T*>(pthis)->Close();
+        }
+        static mfxStatus _GetAudioParam(mfxHDL pthis, mfxAudioParam *par) {
+            return reinterpret_cast<T*>(pthis)->GetAudioParam(par);
+        }
+    };
+
+    template <class T>
+    struct MFXPluginAdapterInternal{};
+    template<>
+    class MFXPluginAdapterInternal<MFXGenericPlugin> : public MFXPluginAdapterBase<MFXGenericPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXGenericPlugin *pPlugin)
+            : MFXPluginAdapterBase<MFXGenericPlugin>(pPlugin)
+        {
+            m_mfxAPI.Submit = _Submit;
+        }
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that )
+            : MFXPluginAdapterBase<MFXGenericPlugin>(that) {
+            m_mfxAPI.Submit = that._Submit;
+        }
+        MFXPluginAdapterInternal<MFXGenericPlugin>& operator = (const MFXPluginAdapterInternal<MFXGenericPlugin> & that) {
+            MFXPluginAdapterBase<MFXGenericPlugin>::operator=(that);
+            m_mfxAPI.Submit = that._Submit;
+            return *this;
+        }
+
+    private:
+        static mfxStatus _Submit(mfxHDL pthis, const mfxHDL *in, mfxU32 in_num, const mfxHDL *out, mfxU32 out_num, mfxThreadTask *task) {
+            return reinterpret_cast<MFXGenericPlugin*>(pthis)->Submit(in, in_num, out, out_num, task);
+        }
+    };
+
+    template<>
+    class MFXPluginAdapterInternal<MFXDecoderPlugin> : public MFXCodecPluginAdapterBase<MFXDecoderPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXDecoderPlugin *pPlugin)
+            : MFXCodecPluginAdapterBase<MFXDecoderPlugin>(pPlugin)
+        {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+        : MFXCodecPluginAdapterBase<MFXDecoderPlugin>(that) {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal<MFXDecoderPlugin>& operator = (const MFXPluginAdapterInternal<MFXDecoderPlugin> & that) {
+            MFXCodecPluginAdapterBase<MFXDecoderPlugin>::operator=(that);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.DecodeHeader = _DecodeHeader;
+            m_codecPlg.GetPayload = _GetPayload;
+            m_codecPlg.DecodeFrameSubmit = _DecodeFrameSubmit;
+        }
+        static mfxStatus _DecodeHeader(mfxHDL pthis, mfxBitstream *bs, mfxVideoParam *par) {
+            return reinterpret_cast<MFXDecoderPlugin*>(pthis)->DecodeHeader(bs, par);
+        }
+        static mfxStatus _GetPayload(mfxHDL pthis, mfxU64 *ts, mfxPayload *payload) {
+            return reinterpret_cast<MFXDecoderPlugin*>(pthis)->GetPayload(ts, payload);
+        }
+        static mfxStatus _DecodeFrameSubmit(mfxHDL pthis, mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out,  mfxThreadTask *task) {
+            return reinterpret_cast<MFXDecoderPlugin*>(pthis)->DecodeFrameSubmit(bs, surface_work, surface_out, task);
+        }
+    };
+
+    template<>
+    class MFXPluginAdapterInternal<MFXAudioDecoderPlugin> : public MFXAudioCodecPluginAdapterBase<MFXAudioDecoderPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXAudioDecoderPlugin *pPlugin)
+            : MFXAudioCodecPluginAdapterBase<MFXAudioDecoderPlugin>(pPlugin)
+        {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+        : MFXAudioCodecPluginAdapterBase<MFXAudioDecoderPlugin>(that) {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal<MFXAudioDecoderPlugin>& operator = (const MFXPluginAdapterInternal<MFXAudioDecoderPlugin> & that) {
+            MFXAudioCodecPluginAdapterBase<MFXAudioDecoderPlugin>::operator=(that);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.DecodeHeader = _DecodeHeader;
+//            m_codecPlg.GetPayload = _GetPayload;
+            m_codecPlg.DecodeFrameSubmit = _DecodeFrameSubmit;
+        }
+        static mfxStatus _DecodeHeader(mfxHDL pthis, mfxBitstream *bs, mfxAudioParam *par) {
+            return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeHeader(bs, par);
+        }
+//        static mfxStatus _GetPayload(mfxHDL pthis, mfxU64 *ts, mfxPayload *payload) {
+  //          return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->GetPayload(ts, payload);
+    //    }
+        static mfxStatus _DecodeFrameSubmit(mfxHDL pthis, mfxBitstream *in, mfxAudioFrame *out, mfxThreadTask *task) {
+            return reinterpret_cast<MFXAudioDecoderPlugin*>(pthis)->DecodeFrameSubmit(in, out, task);
+        }
+    };
+
+    template<>
+    class MFXPluginAdapterInternal<MFXEncoderPlugin> : public MFXCodecPluginAdapterBase<MFXEncoderPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXEncoderPlugin *pPlugin)
+            : MFXCodecPluginAdapterBase<MFXEncoderPlugin>(pPlugin)
+        {
+            m_codecPlg.EncodeFrameSubmit = _EncodeFrameSubmit;
+        }
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+            : MFXCodecPluginAdapterBase<MFXEncoderPlugin>(that) {
+            m_codecPlg.EncodeFrameSubmit = _EncodeFrameSubmit;
+        }
+
+        MFXPluginAdapterInternal<MFXEncoderPlugin>& operator = (const MFXPluginAdapterInternal<MFXEncoderPlugin> & that) {
+            MFXCodecPluginAdapterBase<MFXEncoderPlugin>::operator = (that);
+            m_codecPlg.EncodeFrameSubmit = _EncodeFrameSubmit;
+            return *this;
+        }
+
+    private:
+        static mfxStatus _EncodeFrameSubmit(mfxHDL pthis, mfxEncodeCtrl *ctrl, mfxFrameSurface1 *surface, mfxBitstream *bs, mfxThreadTask *task) {
+            return reinterpret_cast<MFXEncoderPlugin*>(pthis)->EncodeFrameSubmit(ctrl, surface, bs, task);
+        }
+    };
+
+    template<>
+    class MFXPluginAdapterInternal<MFXAudioEncoderPlugin> : public MFXAudioCodecPluginAdapterBase<MFXAudioEncoderPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXAudioEncoderPlugin *pPlugin)
+            : MFXAudioCodecPluginAdapterBase<MFXAudioEncoderPlugin>(pPlugin)
+        {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+        : MFXAudioCodecPluginAdapterBase<MFXAudioEncoderPlugin>(that) {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal<MFXAudioEncoderPlugin>& operator = (const MFXPluginAdapterInternal<MFXAudioEncoderPlugin> & that) {
+            MFXAudioCodecPluginAdapterBase<MFXAudioEncoderPlugin>::operator=(that);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.EncodeFrameSubmit = _EncodeFrameSubmit;
+        }
+        static mfxStatus _EncodeFrameSubmit(mfxHDL pthis, mfxAudioFrame *aFrame, mfxBitstream *out, mfxThreadTask *task) {
+            return reinterpret_cast<MFXAudioEncoderPlugin*>(pthis)->EncodeFrameSubmit(aFrame, out, task);
+        }
+    };
+
+    template<>
+    class MFXPluginAdapterInternal<MFXEncPlugin> : public MFXCodecPluginAdapterBase<MFXEncPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXEncPlugin *pPlugin)
+            : MFXCodecPluginAdapterBase<MFXEncPlugin>(pPlugin)
+        {
+            m_codecPlg.ENCFrameSubmit = _ENCFrameSubmit;
+        }
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+            : MFXCodecPluginAdapterBase<MFXEncPlugin>(that) {
+            m_codecPlg.ENCFrameSubmit = _ENCFrameSubmit;
+        }
+
+        MFXPluginAdapterInternal<MFXEncPlugin>& operator = (const MFXPluginAdapterInternal<MFXEncPlugin> & that) {
+            MFXCodecPluginAdapterBase<MFXEncPlugin>::operator = (that);
+            m_codecPlg.ENCFrameSubmit = _ENCFrameSubmit;
+            return *this;
+        }
+
+    private:
+        static mfxStatus _ENCFrameSubmit(mfxHDL pthis,mfxENCInput *in, mfxENCOutput *out, mfxThreadTask *task) {
+            return reinterpret_cast<MFXEncPlugin*>(pthis)->EncFrameSubmit(in, out, task);
+        }
+    };
+
+
+    template<>
+    class MFXPluginAdapterInternal<MFXVPPPlugin> : public MFXCodecPluginAdapterBase<MFXVPPPlugin>
+    {
+    public:
+        MFXPluginAdapterInternal(MFXVPPPlugin *pPlugin)
+            : MFXCodecPluginAdapterBase<MFXVPPPlugin>(pPlugin)
+        {
+            SetupCallbacks();
+        }
+        MFXPluginAdapterInternal(const MFXPluginAdapterInternal & that)
+            : MFXCodecPluginAdapterBase<MFXVPPPlugin>(that) {
+            SetupCallbacks();
+        }
+
+        MFXPluginAdapterInternal<MFXVPPPlugin>& operator = (const MFXPluginAdapterInternal<MFXVPPPlugin> & that) {
+            MFXCodecPluginAdapterBase<MFXVPPPlugin>::operator = (that);
+            SetupCallbacks();
+            return *this;
+        }
+
+    private:
+        void SetupCallbacks() {
+            m_codecPlg.VPPFrameSubmit = _VPPFrameSubmit;
+            m_codecPlg.VPPFrameSubmitEx = _VPPFrameSubmitEx;
+        }
+        static mfxStatus _VPPFrameSubmit(mfxHDL pthis, mfxFrameSurface1 *surface_in, mfxFrameSurface1 *surface_out, mfxExtVppAuxData *aux, mfxThreadTask *task) {
+            return reinterpret_cast<MFXVPPPlugin*>(pthis)->VPPFrameSubmit(surface_in, surface_out, aux, task);
+        }
+        static mfxStatus _VPPFrameSubmitEx(mfxHDL pthis, mfxFrameSurface1 *surface_in, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxThreadTask *task) {
+            return reinterpret_cast<MFXVPPPlugin*>(pthis)->VPPFrameSubmitEx(surface_in, surface_work, surface_out, task);
+        }
+    };
+}
+
+/* adapter for particular plugin type*/
+template<class T>
+class MFXPluginAdapter
+{
+public:
+    detail::MFXPluginAdapterInternal<T> m_Adapter;
+
+    operator  mfxPlugin () const {
+        return m_Adapter.operator mfxPlugin();
+    }
+
+    MFXPluginAdapter(T* pPlugin = NULL)
+        : m_Adapter(pPlugin)
+    {
+    }
+};
+
+template<class T>
+inline MFXPluginAdapter<T> make_mfx_plugin_adapter(T* pPlugin) {
+
+    MFXPluginAdapter<T> adapt(pPlugin);
+    return adapt;
+}
+
+#endif // __MFXPLUGINPLUSPLUS_H

--- a/mfx/mfxscd.h
+++ b/mfx/mfxscd.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2018-2019 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+#ifndef __MFXSCD_H__
+#define __MFXSCD_H__
+
+#include "mfxenc.h"
+#include "mfxplugin.h"
+
+#define MFX_ENC_SCD_PLUGIN_VERSION 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static const mfxPluginUID MFX_PLUGINID_ENC_SCD = {{ 0xdf, 0xc2, 0x15, 0xb3, 0xe3, 0xd3, 0x90, 0x4d, 0x7f, 0xa5, 0x04, 0x12, 0x7e, 0xf5, 0x64, 0xd5 }};
+
+/* SCD Extended Buffer Ids */
+enum {
+    MFX_EXTBUFF_SCD = MFX_MAKEFOURCC('S','C','D',' ')
+};
+
+/* SceneType */
+enum {
+    MFX_SCD_SCENE_SAME        = 0x00,
+    MFX_SCD_SCENE_NEW_FIELD_1 = 0x01,
+    MFX_SCD_SCENE_NEW_FIELD_2 = 0x02,
+    MFX_SCD_SCENE_NEW_PICTURE = MFX_SCD_SCENE_NEW_FIELD_1 | MFX_SCD_SCENE_NEW_FIELD_2
+};
+
+MFX_PACK_BEGIN_USUAL_STRUCT()
+typedef struct {
+    mfxExtBuffer Header;
+
+    mfxU16 SceneType;
+    mfxU16 reserved[27];
+} mfxExtSCD;
+MFX_PACK_END()
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif
+

--- a/mfx/mfxvideo++.h
+++ b/mfx/mfxvideo++.h
@@ -1,0 +1,188 @@
+// Copyright (c) 2017 Intel Corporation
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef __MFXVIDEOPLUSPLUS_H
+#define __MFXVIDEOPLUSPLUS_H
+
+#include "mfxvideo.h"
+#include "mfxenc.h"
+#include "mfxpak.h"
+
+class MFXVideoSession
+{
+public:
+    MFXVideoSession(void) { m_session = (mfxSession) 0; }
+    virtual ~MFXVideoSession(void) { Close(); }
+
+    virtual mfxStatus Init(mfxIMPL impl, mfxVersion *ver) { return MFXInit(impl, ver, &m_session); }
+    virtual mfxStatus InitEx(mfxInitParam par) { return MFXInitEx(par, &m_session); }
+    virtual mfxStatus Close(void)
+    {
+        mfxStatus mfxRes;
+        mfxRes = MFXClose(m_session); m_session = (mfxSession) 0;
+        return mfxRes;
+    }
+
+    virtual mfxStatus QueryIMPL(mfxIMPL *impl) { return MFXQueryIMPL(m_session, impl); }
+    virtual mfxStatus QueryVersion(mfxVersion *version) { return MFXQueryVersion(m_session, version); }
+
+    virtual mfxStatus JoinSession(mfxSession child_session) { return MFXJoinSession(m_session, child_session);}
+    virtual mfxStatus DisjoinSession( ) { return MFXDisjoinSession(m_session);}
+    virtual mfxStatus CloneSession( mfxSession *clone) { return MFXCloneSession(m_session, clone);}
+    virtual mfxStatus SetPriority( mfxPriority priority) { return MFXSetPriority(m_session, priority);}
+    virtual mfxStatus GetPriority( mfxPriority *priority) { return MFXGetPriority(m_session, priority);}
+
+    virtual mfxStatus SetBufferAllocator(mfxBufferAllocator *allocator) { return MFXVideoCORE_SetBufferAllocator(m_session, allocator); }
+    virtual mfxStatus SetFrameAllocator(mfxFrameAllocator *allocator) { return MFXVideoCORE_SetFrameAllocator(m_session, allocator); }
+    virtual mfxStatus SetHandle(mfxHandleType type, mfxHDL hdl) { return MFXVideoCORE_SetHandle(m_session, type, hdl); }
+    virtual mfxStatus GetHandle(mfxHandleType type, mfxHDL *hdl) { return MFXVideoCORE_GetHandle(m_session, type, hdl); }
+    virtual mfxStatus QueryPlatform(mfxPlatform* platform) { return MFXVideoCORE_QueryPlatform(m_session, platform); }
+
+    virtual mfxStatus SyncOperation(mfxSyncPoint syncp, mfxU32 wait) { return MFXVideoCORE_SyncOperation(m_session, syncp, wait); }
+
+    virtual mfxStatus DoWork() { return MFXDoWork(m_session); }
+
+    virtual operator mfxSession (void) { return m_session; }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+private:
+    MFXVideoSession(const MFXVideoSession &);
+    void operator=(MFXVideoSession &);
+};
+
+class MFXVideoENCODE
+{
+public:
+
+    MFXVideoENCODE(mfxSession session) { m_session = session; }
+    virtual ~MFXVideoENCODE(void) { Close(); }
+
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVideoENCODE_Query(m_session, in, out); }
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) { return MFXVideoENCODE_QueryIOSurf(m_session, par, request); }
+    virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoENCODE_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoENCODE_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXVideoENCODE_Close(m_session); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoENCODE_GetVideoParam(m_session, par); }
+    virtual mfxStatus GetEncodeStat(mfxEncodeStat *stat) { return MFXVideoENCODE_GetEncodeStat(m_session, stat); }
+
+    virtual mfxStatus EncodeFrameAsync(mfxEncodeCtrl *ctrl, mfxFrameSurface1 *surface, mfxBitstream *bs, mfxSyncPoint *syncp) { return MFXVideoENCODE_EncodeFrameAsync(m_session, ctrl, surface, bs, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+class MFXVideoDECODE
+{
+public:
+
+    MFXVideoDECODE(mfxSession session) { m_session = session; }
+    virtual ~MFXVideoDECODE(void) { Close(); }
+
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVideoDECODE_Query(m_session, in, out); }
+    virtual mfxStatus DecodeHeader(mfxBitstream *bs, mfxVideoParam *par) { return MFXVideoDECODE_DecodeHeader(m_session, bs, par); }
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) { return MFXVideoDECODE_QueryIOSurf(m_session, par, request); }
+    virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoDECODE_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoDECODE_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXVideoDECODE_Close(m_session); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoDECODE_GetVideoParam(m_session, par); }
+
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat) { return MFXVideoDECODE_GetDecodeStat(m_session, stat); }
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) {return MFXVideoDECODE_GetPayload(m_session, ts, payload); }
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) { return MFXVideoDECODE_SetSkipMode(m_session, mode); }
+    virtual mfxStatus DecodeFrameAsync(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, mfxSyncPoint *syncp) { return MFXVideoDECODE_DecodeFrameAsync(m_session, bs, surface_work, surface_out, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+class MFXVideoVPP
+{
+public:
+
+    MFXVideoVPP(mfxSession session) { m_session = session; }
+    virtual ~MFXVideoVPP(void) { Close(); }
+
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVideoVPP_Query(m_session, in, out); }
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest request[2]) { return MFXVideoVPP_QueryIOSurf(m_session, par, request); }
+    virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoVPP_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoVPP_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXVideoVPP_Close(m_session); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoVPP_GetVideoParam(m_session, par); }
+    virtual mfxStatus GetVPPStat(mfxVPPStat *stat) { return MFXVideoVPP_GetVPPStat(m_session, stat); }
+    virtual mfxStatus RunFrameVPPAsync(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux, mfxSyncPoint *syncp) { return MFXVideoVPP_RunFrameVPPAsync(m_session, in, out, aux, syncp); }
+    virtual mfxStatus RunFrameVPPAsyncEx(mfxFrameSurface1 *in, mfxFrameSurface1 *work, mfxFrameSurface1 **out, mfxSyncPoint *syncp) {return MFXVideoVPP_RunFrameVPPAsyncEx(m_session, in, work, out, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+class MFXVideoENC
+{
+public:
+
+    MFXVideoENC(mfxSession session) { m_session = session; }
+    virtual ~MFXVideoENC(void) { Close(); }
+
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVideoENC_Query(m_session, in, out); }
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) { return MFXVideoENC_QueryIOSurf(m_session, par, request); }
+    virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoENC_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoENC_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXVideoENC_Close(m_session); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoENC_GetVideoParam(m_session, par); }
+    virtual mfxStatus ProcessFrameAsync(mfxENCInput *in, mfxENCOutput *out, mfxSyncPoint *syncp) { return MFXVideoENC_ProcessFrameAsync(m_session, in, out, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+class MFXVideoPAK
+{
+public:
+
+    MFXVideoPAK(mfxSession session) { m_session = session; }
+    virtual ~MFXVideoPAK(void) { Close(); }
+
+    virtual mfxStatus Query(mfxVideoParam *in, mfxVideoParam *out) { return MFXVideoPAK_Query(m_session, in, out); }
+    virtual mfxStatus QueryIOSurf(mfxVideoParam *par, mfxFrameAllocRequest *request) { return MFXVideoPAK_QueryIOSurf(m_session, par, request); }
+    virtual mfxStatus Init(mfxVideoParam *par) { return MFXVideoPAK_Init(m_session, par); }
+    virtual mfxStatus Reset(mfxVideoParam *par) { return MFXVideoPAK_Reset(m_session, par); }
+    virtual mfxStatus Close(void) { return MFXVideoPAK_Close(m_session); }
+
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) { return MFXVideoPAK_GetVideoParam(m_session, par); }
+    //virtual mfxStatus GetEncodeStat(mfxEncodeStat *stat) { return MFXVideoENCODE_GetEncodeStat(m_session, stat); }
+
+    virtual mfxStatus ProcessFrameAsync(mfxPAKInput *in, mfxPAKOutput *out, mfxSyncPoint *syncp) { return MFXVideoPAK_ProcessFrameAsync(m_session, in, out, syncp); }
+
+protected:
+
+    mfxSession m_session;                                       // (mfxSession) handle to the owning session
+};
+
+#endif // __MFXVIDEOPLUSPLUS_H


### PR DESCRIPTION
I'm assuming that the headers came from https://github.com/Intel-Media-SDK/MediaSDK.

Downloaded by
```bash
for _mfx_header in mfx{video,audio,plugin}++ mfx{adapter,pcp,scd,dispatcherprefixedfunctions}; do
    [[ -f "mfx/$_mfx_header.h" ]] || wget "https://raw.githubusercontent.com/Intel-Media-SDK/MediaSDK/master/api/include/$_mfx_header.h" -O "mfx/$_mfx_header.h"
done
```