### PR TITLE
main: use lowercase windows header include

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <Windows.h>
+#include <windows.h>
 #include <stringapiset.h>
 
 #include <new>


### PR DESCRIPTION
By default MinGW on GNU/Linux uses lower case headers and on case-sensitive file-systems the header won't be found.
So lower-casing this import will solve that issue while not impacting Windows.

This issue got introduced via: https://github.com/lu-zero/mfx_dispatch/commit/4ba92bcf29199484d22e08f7de231c9835ef5e8b#diff-7ec3c68a81efff79b6ca22ac1f1eabbaR21