### PR TITLE
detect winstore builds with a regular mingw32 toolchain

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,20 @@ AS_CASE([${host_os}],
         AM_CONDITIONAL([WINDOWS_STORE], [true])
         DLLIB="$(DLLIB) -ldxgi"
     ],
+    [mingw32], [
+        AC_PREPROC_IFELSE([AC_LANG_PROGRAM(
+          [[#include <winapifamily.h>
+           #if WINAPI_FAMILY_PARTITION (WINAPI_PARTITION_DESKTOP)
+           # error Win32 Desktop build
+           #endif
+          ]],[[;]])
+        ],[
+            AM_CONDITIONAL([WINDOWS_STORE], [true])
+            DLLIB="$(DLLIB) -ldxgi"
+        ],[
+            AM_CONDITIONAL([WINDOWS_STORE], [false])
+        ])
+    ],
     [
         AM_CONDITIONAL([WINDOWS_STORE], [false])
     ]


### PR DESCRIPTION
It's trigerred with a mingw32winrt or mingw32uwp toolchain.

Forcing the WINAPI_FAMILY should be enough to trigger the winstore mode.