### PR TITLE
Fix linking statically with intel_gfx_api-x86.dll

### DIFF
--- a/src/intel_api_factory.h
+++ b/src/intel_api_factory.h
@@ -25,8 +25,8 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-HRESULT APIENTRY InitialiseMediaSession(_Out_ HANDLE* handle, _In_ LPVOID lpParam, _Reserved_ LPVOID lpReserved);
-HRESULT APIENTRY DisposeMediaSession(_In_ const HANDLE handle);
+HRESULT InitialiseMediaSession(_Out_ HANDLE* handle, _In_ LPVOID lpParam, _Reserved_ LPVOID lpReserved);
+HRESULT DisposeMediaSession(_In_ const HANDLE handle);
 
 #ifdef __cplusplus
 }

--- a/src/intel_gfx_api-x86.def
+++ b/src/intel_gfx_api-x86.def
@@ -1,4 +1,4 @@
 LIBRARY intel_gfx_api-x86.dll
 EXPORTS
-InitialiseMediaSession@12
-DisposeMediaSession@4
+InitialiseMediaSession
+DisposeMediaSession


### PR DESCRIPTION
Should fix #88 when it is possible to link statically to the Intel drivers again.