### PR TITLE
Don't change the calling convention of x86 gfx api

### DIFF
--- a/src/intel_api_factory.h
+++ b/src/intel_api_factory.h
@@ -25,8 +25,8 @@ extern "C"
 {
 #endif /* __cplusplus */
 
-HRESULT InitialiseMediaSession(_Out_ HANDLE* handle, _In_ LPVOID lpParam, _Reserved_ LPVOID lpReserved);
-HRESULT DisposeMediaSession(_In_ const HANDLE handle);
+HRESULT WINAPIV InitialiseMediaSession(_Out_ HANDLE* handle, _In_ LPVOID lpParam, _Reserved_ LPVOID lpReserved);
+HRESULT WINAPIV DisposeMediaSession(_In_ const HANDLE handle);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Upstream MediaSDK, since ae85eb2, uses __cdecl, which corresponds to
WINAPIV in mingw64 and MSDK. The removal of APIENTRY (since f45c0c2)
changes the calling convention from __stdcall.

The removal of the '@' name decorations (also gone since f45c0c2)
remains.

Co-authored-by: Steve Lhomme <robux4@ycbcr.xyz>

See also https://code.videolan.org/videolan/vlc/-/merge_requests/794.