### PR TITLE
Fix the MFX plugins loading issue on linux

### DIFF
--- a/src/mfxloader.cpp
+++ b/src/mfxloader.cpp
@@ -452,7 +452,24 @@ mfxStatus MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32 
       if (MFX::g_GlobalCtx.m_plugins.empty()) {
         // Parsing plugin configuration file and loading information of
         // _all_ plugins registered on the system.
+#if defined(__linux__)
+        // Hardcode common plugins paths for most linux distros in case of
+        // the legacy mfxdispatcher is configured to static build.
+        const char *plugins_paths[4] = { "/plugins.cfg",
+                                         "/usr/share/mfx/plugins.cfg",
+                                         "/usr/local/share/mfx/plugins.cfg",
+                                         "/opt/intel/mediasdk/plugins/plugins.cfg" };
+        for (int i = 0; i < sizeof(plugins_paths) / sizeof(plugins_paths[0]); i++) {
+          FILE *fp = NULL;
+          if ((fp = fopen(plugins_paths[i], "r")) != NULL) {
+            fclose(fp);
+            parse(plugins_paths[i], MFX::g_GlobalCtx.m_plugins);
+            break;
+          }
+        }
+#else
         parse(MFX_PLUGINS_CONF_DIR "/plugins.cfg", MFX::g_GlobalCtx.m_plugins);
+#endif
       }
 
       // search for plugin description


### PR DESCRIPTION
In the static build of MFX dispatcher on Linux, plugins are not shipped with dispatcher. Therefore, the ffmpeg linked to this dispatcher cannot find the location of plugins according to plugins.cfg, and causes HEVC encoding to fail.

So we should hardcode the default paths of some common plugins.cfg so that dispatcher can find plugins correctly.

Add a series of fallback paths for plugins.cfg, this should cover most linux distros.

Signed-off-by: nyanmisaka <nst799610810@gmail.com>