### PR TITLE
Fix for porting this repo in vcpkg, and use as a dependency of ffmpeg.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     src/mfx_load_plugin.cpp
     src/mfx_plugin_hive.cpp
     src/mfx_win_reg_key.cpp
+
+    # If not add this file, a ffmpeg build test will not pass due to missing symbols in this file
+    # (Building ffmpeg in vcpkg use MSVC toolchain can reproduce)
+    src/mfx_driver_store_loader.cpp
   )
 endif (CMAKE_SYSTEM_NAME MATCHES "Windows")
 
@@ -53,9 +57,24 @@ add_definitions(
   -D_LIB
 )
 
-configure_file (${CMAKE_SOURCE_DIR}/libmfx.pc.cmake ${CMAKE_BINARY_DIR}/libmfx.pc @ONLY)
+# As this library might be used by ffmpeg, and in vcpkg build pipeline, the .a suffix is not recognized by the linker,
+# thus, we need to rename to .lib. (MSVC toolchain should all need this)
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  configure_file (${CMAKE_SOURCE_DIR}/libmfx.pc.win.cmake ${CMAKE_BINARY_DIR}/libmfx.pc @ONLY)
+else()
+  configure_file (${CMAKE_SOURCE_DIR}/libmfx.pc.cmake ${CMAKE_BINARY_DIR}/libmfx.pc @ONLY)
+endif()
+
 
 add_library( mfx STATIC ${SOURCES} )
+
+# As this library might be used by ffmpeg, and in vcpkg build pipeline, mfx.lib won't be recognized by linker,
+# thus, we need to rename to libmfx.lib
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  set_target_properties(mfx
+          PROPERTIES PREFIX lib)
+endif()
+
 install (DIRECTORY ${CMAKE_SOURCE_DIR}/mfx DESTINATION ${CMAKE_INSTALL_PREFIX}/include FILES_MATCHING PATTERN "*.h")
 install (FILES ${CMAKE_BINARY_DIR}/libmfx.pc DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
 install (TARGETS mfx ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)

--- a/libmfx.pc.win.cmake
+++ b/libmfx.pc.win.cmake
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: libmfx
+Description: Intel Media SDK Dispatched static library
+Version: 2013
+Requires:
+Requires.private:
+Conflicts:
+Libs: -L${libdir} -lsupc++ ${libdir}/libmfx.lib
+Libs.private:
+Cflags: -I${includedir} -I@INTELMEDIASDK_PATH@

--- a/src/mfx_driver_store_loader.cpp
+++ b/src/mfx_driver_store_loader.cpp
@@ -24,6 +24,10 @@
 #include "mfx_dispatcher_log.h"
 #include "mfx_load_dll.h"
 
+// If not add this, building ffmpeg in vcpkg will fail missing StringFromGUID2 symbol
+// As the ffmpeg building doesn't link Ole32
+#pragma comment(lib, "Ole32.lib")
+
 namespace MFX
 {
 


### PR DESCRIPTION
I'm adding this repo as a port in vcpkg, to make it as a depencency of ffmpeg, enabling the qsv support of vcpkg's ffmpeg port. I found this changes are needed to make vcpkg successfully build ffmpeg with qsv support. So I'm trying to merge these changes to upstream to avoid applying patches on vcpkg port side.