### PR TITLE
fix UWP build in ming-w64

### DIFF
--- a/src/mfx_driver_store_loader.h
+++ b/src/mfx_driver_store_loader.h
@@ -35,6 +35,13 @@
 #endif
 #endif
 
+#if defined(__MINGW64_VERSION_MAJOR) && WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP)
+// mingw-w64 doesn't set these types for WINAPI_PARTITION_APP
+typedef DWORD      DEVINST;
+typedef DEVINST    *PDEVINST;
+typedef ULONG      REGDISPOSITION;
+#endif
+
 namespace MFX
 {
 


### PR DESCRIPTION
minwg-w64 doesn't define these types in UWP mode and would require a bit of code refactoring to do so.