### PR TITLE
Fix UWP compilation

### DIFF
--- a/src/mfx_driver_store_loader.cpp
+++ b/src/mfx_driver_store_loader.cpp
@@ -79,6 +79,7 @@ DriverStoreLoader::~DriverStoreLoader(void)
 
 bool DriverStoreLoader::GetDriverStorePath(wchar_t * path, DWORD dwPathSize, mfxU32 deviceID)
 {
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     if (path == NULL || dwPathSize == 0)
     {
         return false;
@@ -176,6 +177,7 @@ bool DriverStoreLoader::GetDriverStorePath(wchar_t * path, DWORD dwPathSize, mfx
             }
         }
     }
+#endif // MEDIASDK_UWP_DISPATCHER
 
     DISPATCHER_LOG_INFO(("DriverStore path isn't found\n"));
     return false;

--- a/src/mfx_library_iterator.cpp
+++ b/src/mfx_library_iterator.cpp
@@ -159,6 +159,7 @@ void MFXLibraryIterator::Release(void)
 
 } // void MFXLibraryIterator::Release(void)
 
+#if !defined(MEDIASDK_UWP_DISPATCHER)
 DECLSPEC_NOINLINE HMODULE GetThisDllModuleHandle()
 {
   HMODULE hDll = NULL;
@@ -168,6 +169,7 @@ DECLSPEC_NOINLINE HMODULE GetThisDllModuleHandle()
                       reinterpret_cast<LPCWSTR>(&GetThisDllModuleHandle), &hDll);
   return hDll;
 }
+#endif
 
 // wchar_t* sImplPath must be allocated with size not less then msdk_disp_path_len
 bool GetImplPath(int storageID, wchar_t* sImplPath)
@@ -180,6 +182,7 @@ bool GetImplPath(int storageID, wchar_t* sImplPath)
     case MFX_APP_FOLDER:
         hModule = 0;
         break;
+#if !defined(MEDIASDK_UWP_DISPATCHER)
     case MFX_PATH_MSDK_FOLDER:
         hModule = GetThisDllModuleHandle();
         HMODULE exeModule = GetModuleHandleW(NULL);
@@ -187,6 +190,7 @@ bool GetImplPath(int storageID, wchar_t* sImplPath)
         if (!hModule || !exeModule || hModule == exeModule)
             return false;
         break;
+#endif
     }
 
     DWORD nSize = 0;


### PR DESCRIPTION
Avoid some forbidden calls which are not necessary. We link directly with the installed DLL.